### PR TITLE
feat: content view version cleaup playbook and job template

### DIFF
--- a/playbooks/content_view_version_cleanup.yml
+++ b/playbooks/content_view_version_cleanup.yml
@@ -1,0 +1,14 @@
+---
+- name: 'RaBe Foreman Playbook : Content View Version Cleanup'
+  hosts: all
+  gather_facts: false
+  collections:
+    - theforeman.foreman
+  vars:
+    rabe_foreman_content_view_version_cleanup_keep: 3
+  tasks:
+    - name: 'RaBe Foreman Playbook : Foreman : Content View Version Cleanup'
+      ansible.builtin.include_role:
+        name: theforeman.foreman.content_view_version_cleanup
+      vars:
+        foreman_content_view_version_cleanup_keep: {{ rabe_foreman_content_view_version_cleanup_keep }}

--- a/roles/foreman/files/job_templates/rabe_foreman_version_cleanup_content_view.erb
+++ b/roles/foreman/files/job_templates/rabe_foreman_version_cleanup_content_view.erb
@@ -1,0 +1,1 @@
+<%= render_template('Ansible - Run playbook', :playbook => '- import_playbook: radiorabe.rabe_foreman.content_view_version_cleanup') %>

--- a/roles/foreman/tasks/job_templates.yaml
+++ b/roles/foreman/tasks/job_templates.yaml
@@ -58,6 +58,15 @@
             kind: job_template
             model: JobTemplate
             file_name: '{{ role_path }}/../../../rabe_foreman/roles/foreman/files/job_templates/rabe_foreman_promote_content_views.erb'
+          - name: RaBe Foreman - Version Cleanup Content Views
+            state: present
+            job_category: RaBe Foreman
+            description_format: RaBe Foreman - Version Cleanup Content Views
+            snippet: false
+            provider_type: Ansible
+            kind: job_template
+            model: JobTemplate
+            file_name: '{{ role_path }}/../../../rabe_foreman/roles/foreman/files/job_templates/rabe_foreman_version_cleanup_content_view.erb'
       when: not ansible_check_mode
   always:
     - name: 'RaBe Foreman Config : Lock All Job Templates'


### PR DESCRIPTION
We need to remove old content views at a regular interval esp. to help getting outdated contents in a published view out of the system over time.