### PR TITLE
fix: s/mysql/postgresql/

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -12,7 +12,7 @@ tags:
 dependencies:
   ansible.posix: ">=1.3.0"
   community.general: ">=3.7.0"
-  community.mysql: ">=3.8.0" # for zabbix
+  community.postgresql: ">=3.3.0" # for zabbix
   community.zabbix: ">=1.9.0"
   radiorabe.common: ">=0.2.0"
   radiorabe.foreman: ">=0.7.0"


### PR DESCRIPTION
because the community.zabbix roles default to postgresql
