### PR TITLE
feat: Create dmz virtualization server resources

### DIFF
--- a/roles/content/tasks/products.yaml
+++ b/roles/content/tasks/products.yaml
@@ -541,7 +541,7 @@
         label: AlmaLinux_OS_Generic_Cloud_Cloud-init_image
         description: > 
           The Generic Cloud image is a general purpose virtual machine image
-          that contains the Cloud-init (opens new window)package. During boot,
+          that contains the Cloud-init package. During boot,
           cloud-init will take configuration options from cloud metadata and
           initialize a system accordingly. This may include network
           configuration, user's SSH key pair installation, attaching storage
@@ -551,7 +551,7 @@
             label: AlmaLinux_OS_Generic_Cloud_Cloud-init_image
             description: >
               The Generic Cloud image is a general purpose virtual machine
-              image that contains the Cloud-init (opens new window)package.
+              image that contains the Cloud-init package.
               During boot, cloud-init will take configuration options from
               cloud metadata and initialize a system accordingly. This may
               include network configuration, user's SSH key pair installation,

--- a/roles/content/tasks/products.yaml
+++ b/roles/content/tasks/products.yaml
@@ -537,3 +537,31 @@
             url: https://aquasecurity.github.io/trivy-repo/rpm/releases/8/x86_64
             download_policy: on_demand
             auto_enabled: false
+      - name: AlmaLinux OS Generic Cloud (Cloud-init) image
+        label: AlmaLinux_OS_Generic_Cloud_Cloud-init_image
+        description: > 
+          The Generic Cloud image is a general purpose virtual machine image
+          that contains the Cloud-init (opens new window)package. During boot,
+          cloud-init will take configuration options from cloud metadata and
+          initialize a system accordingly. This may include network
+          configuration, user's SSH key pair installation, attaching storage
+          devices, etc.
+        repositories:
+          - name: AlmaLinux OS Generic Cloud (Cloud-init) image
+            label: AlmaLinux_OS_Generic_Cloud_Cloud-init_image
+            description: >
+              The Generic Cloud image is a general purpose virtual machine
+              image that contains the Cloud-init (opens new window)package.
+              During boot, cloud-init will take configuration options from
+              cloud metadata and initialize a system accordingly. This may
+              include network configuration, user's SSH key pair installation,
+              attaching storage devices, etc.
+
+              To be used with libvirt, the image has to be altered with 
+              guestfs-tools and
+
+              virt-customize -a
+              Downloads/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2 --install
+              subscription-manager --run-command "echo -e 'network:\n  config:
+              disabled\n' > /etc/cloud/cloud.cfg"
+            content_type: file

--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -108,3 +108,43 @@
         organization: RaBe
         location: Randweg
         compute_resource: ovirt
+      - name: AlmaLinux 9 DMZ Virtualization Server
+        description: AlmaLinux 9 general purpose virtual machines.
+        parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9
+        organization: RaBe
+        location: Randweg
+        domain: dmz.int.rabe.ch
+        subnet: dmz
+        ansible_roles:
+          - radiorabe.foreman_libvirt.libvirt
+          - radiorabe.common.download_file
+        parameters:
+          - name: download_file_destination
+            parameter_type: string
+            value: /var/lib/libvirt/images/
+          - name: download_file_url
+            parameter_type: string
+            value: https://foreman.service.int.rabe.ch/pulp/content/RaBe/Library/custom/AlmaLinux_OS_Generic_Cloud_Cloud-init_image/AlmaLinux_OS_Generic_Cloud_Cloud-init_image/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2
+          - name: remote_execution_ssh_keys
+            parameter_type: string
+            value: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC4arUJdueCQnOkjVOvrruEEs9M/lKw2ITorTTEIIFgcNAGZNs+SFFxugtMWY2jzrcHoxwSZel3eAMjvS76by6z3ZqZUvMxVHACR0FZvP2WtLk2BjgDjYdmBGDpMArvncHkaiVtjEaruwXVqO+64qsrYXQ3qhUiah+9soFHghWZWS3i+Dnd1JiNFX6TZP+ooqshBaClspAfcywsqFhsFNeU50rlsl11T13vLmZ/G140VF7uhaZ2ukOEj3HSSBcQ1DKIyanoo4fpAG8ealo6Nur0t5rlO67ACgRjLIVBS0LnVG5tvXtnKbz6A0uoUHC5aesDnDUskImWiKnz/6r2QenMkzD08BT6VlaFHhpp4ve2/d2lmjAl4EXvNOCwGsGV9A5BB1O130dwRk85Cxutxm94tuThElWlu37BB8pxOYz8qD+Vph5TVbC4mi1/30hUQffll0x/mcplJsFLY9H7eX0S+Ki2W++udWQ4HfwxbxXlJltMLEw7fhSxEQdGNfIaoM0= foreman@foreman.service.int.rabe.ch
+          - name: network_connections
+            parameter_type: yaml
+            value: 
+              - name: Bond bond0
+                state: up
+              - name: dmz
+                interface_name: dmz
+                type: bridge
+                ip:
+                  dhcp4: false
+                  auto6: false
+              - name: Vlan bond0.133
+                interface_name: bond0.133
+                type: vlan
+                vlan:
+                  id: '133'
+                parent: Bond bond0
+                controller: dmz
+                port_type: bridge
+

--- a/roles/infrastructure/tasks/compute_resources.yaml
+++ b/roles/infrastructure/tasks/compute_resources.yaml
@@ -23,3 +23,37 @@
           # TODO: read me from api
           ovirt_quota: 2e50d818-c01b-4a0a-aa61-4b68cd3bb579
           use_v4: true
+      - name: server-008.dmz-admin.int.rabe.ch
+        state: present
+        description: DMZ libvirt hypervisor server-008.dmz-admin.int.rabe.ch
+        organizations:
+          - RaBe
+        locations:
+          - Randweg
+        provider: libvirt
+        provider_params:
+          url: qemu+ssh://root@server-008.dmz-admin.int.rabe.ch/system
+          images:
+            - name: AlmaLinux-9-GenericCloud-9.4-20240507.x86_64.qcow2
+              operatingsystem: AlmaLinux 9
+              architecture: "x86_64"
+              image_username: almalinux
+              user_data: true
+              uuid: /var/lib/libvirt/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2
+      - name: server-009.dmz-admin.int.rabe.ch
+        state: present
+        description: DMZ libvirt hypervisor server-009.dmz-admin.int.rabe.ch
+        organizations:
+          - RaBe
+        locations:
+          - Randweg
+        provider: libvirt
+        provider_params:
+          url: qemu+ssh://root@server-009.dmz-admin.int.rabe.ch/system
+          images:
+            - name: AlmaLinux-9-GenericCloud-9.4-20240507.x86_64.qcow2
+              operatingsystem: AlmaLinux 9
+              architecture: "x86_64"
+              image_username: almalinux
+              user_data: true
+              uuid: /var/lib/libvirt/images/AlmaLinux-9-GenericCloud-latest.x86_64.qcow2


### PR DESCRIPTION
Creates resources required by dmz virtualization servers.
* AlmaLinux 9 cloudinit image repository
* Hostgroup with Ansible roles and parameters
* Compute resources and image configuration