### PR TITLE
feat(compute_profiles): added secondary disk according to concept

### DIFF
--- a/roles/infrastructure/tasks/compute_profiles.yaml
+++ b/roles/infrastructure/tasks/compute_profiles.yaml
@@ -17,6 +17,11 @@
                   capacity: 10G
                   allocation: 10G
                   format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
+                  allocation: 10G
+                  format_type: qcow2
               interfaces_attributes:
                 0:
                   type: bridge
@@ -35,6 +40,11 @@
                   capacity: 10G
                   allocation: 10G
                   format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
+                  allocation: 10G
+                  format_type: qcow2
               interfaces_attributes:
                 0:
                   type: bridge
@@ -51,6 +61,11 @@
                 0:
                   pool_name: default
                   capacity: 10G
+                  allocation: 10G
+                  format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
                   allocation: 10G
                   format_type: qcow2
               interfaces_attributes:
@@ -71,6 +86,11 @@
                   capacity: 10G
                   allocation: 10G
                   format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
+                  allocation: 10G
+                  format_type: qcow2
               interfaces_attributes:
                 0:
                   type: bridge
@@ -89,6 +109,11 @@
                   capacity: 10G
                   allocation: 10G
                   format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
+                  allocation: 10G
+                  format_type: qcow2
               interfaces_attributes:
                 0:
                   type: bridge
@@ -105,6 +130,11 @@
                 0:
                   pool_name: default
                   capacity: 10G
+                  allocation: 10G
+                  format_type: qcow2
+                1:
+                  pool_name: default
+                  capacity: 30G
                   allocation: 10G
                   format_type: qcow2
               interfaces_attributes:


### PR DESCRIPTION
Adds 30GB secondary disk to VM compute profiles for server-008 and server-009