### PR TITLE
feat(host_groups): vm-0043 hostgroup added with parameters required by the vm

### DIFF
--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -118,7 +118,51 @@
         organization: RaBe
         location: Randweg
         compute_resource: ovirt
-      - name: AlmaLinux 9 DMZ Virtualization Server
+      - name: vm-0043.service.int.rabe.ch
+        description: >
+          AlmaLinux 9 VM for Letsencrypt certificate renewal on reverse proxies
+        parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 VMs
+        organization: RaBe
+        location: Randweg
+        compute_resource: ovirt
+        ansible_roles:
+          - radiorabe.certbot.certbot
+        parameters:
+          - name: certbot_acme_account_mail
+            parameter_type: string
+            value: it@rabe.ch
+          - name: certbot_certificates
+            parameter_type: string
+            value: letest.rabe.ch
+          - name: certbot_remote_hosts
+            parameter_type: yaml
+            value:
+              - vm-2001.dmz.int.rabe.ch
+              - vm-2002.dmz.int.rabe.ch
+          - name: firewall
+            parameter_type: yaml
+            value:
+              - zone: service
+                state: present
+                permanent: true
+                immediate: true
+              - zone: service
+                interface: enp1s0
+                state: present
+                permanent: true
+                immediate: true
+              - zone: service
+                service:
+                  - cockpit
+                  - ssh
+                  - http
+                  - pmcd
+                state: enabled
+                permanent: true
+                immediate: true
+              - set_default_zone: drop
+                permanent: true
+                immediate: true      - name: AlmaLinux 9 DMZ Virtualization Server
         description: AlmaLinux 9 general purpose virtual machines.
         parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9
         organization: RaBe

--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -124,7 +124,6 @@
         parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 VMs
         organization: RaBe
         location: Randweg
-        compute_resource: ovirt
         ansible_roles:
           - radiorabe.certbot.certbot
         parameters:
@@ -162,7 +161,8 @@
                 immediate: true
               - set_default_zone: drop
                 permanent: true
-                immediate: true      - name: AlmaLinux 9 DMZ Virtualization Server
+                immediate: true
+      - name: AlmaLinux 9 DMZ Virtualization Server
         description: AlmaLinux 9 general purpose virtual machines.
         parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9
         organization: RaBe

--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -131,8 +131,10 @@
             parameter_type: string
             value: it@rabe.ch
           - name: certbot_certificates
-            parameter_type: string
-            value: letest.rabe.ch
+            parameter_type: yaml
+            value:
+              - letest.rabe.ch
+              - dmz-rev-proxy.ewb.rabe.ch
           - name: certbot_remote_hosts
             parameter_type: yaml
             value:


### PR DESCRIPTION
adds hostgroup for vm-0043.service.int.rabe.ch with required parameters and ansible roles