### PR TITLE
feat(content): Remove Foreman Client 3.9 repos

### DIFF
--- a/roles/content/tasks/activation_keys.yaml
+++ b/roles/content/tasks/activation_keys.yaml
@@ -37,8 +37,6 @@
             override: enabled
           - label: RaBe_zabbix70_zabbix70
             override: enabled
-          - label: RaBe_foremanclient39el9_foreman39el9_client
-            override: enabled
       - name: "CentOS 7"
         lifecycle_environment: "Prod"
         content_view: "CentOS 7 x86_64"
@@ -57,8 +55,6 @@
             override: disabled
           - label: RaBe_c7_c7_sclo
             override: disabled
-          - label: RaBe_foremanclient39el7_foreman39el7_client
-            override: enabled
           # disable both until end of migration
           - label: RaBe_c7_c7_storage_glusterfs312
             override: disabled

--- a/roles/content/tasks/products.yaml
+++ b/roles/content/tasks/products.yaml
@@ -119,12 +119,6 @@
             url: https://yum.theforeman.org/client/3.6/el8/x86_64/
             download_policy: on_demand
             auto_enabled: false
-          - name: CentOS Stream 8 Foreman client 3.9 x86_64
-            content_type: yum
-            label: cs8s_foreman39_client
-            url: https://yum.theforeman.org/client/3.9/el8/x86_64/
-            download_policy: on_demand
-            auto_enabled: false
       # EL8 product is here to support LEAPPing from EL7
       - name: AlmaLinux 8
         label: alma8
@@ -308,31 +302,13 @@
       # Foreman 3.9
       - name: Foreman Client 3.9 EL7
         label: foremanclient39el7
-        repositories:
-          - name: Foreman Client 3.9 EL7 x86_64
-            content_type: yum
-            label: foreman39el7_client
-            url: https://yum.theforeman.org/client/3.9/el7/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       - name: Foreman Client 3.9 EL8
         label: foremanclient39el8
-        repositories:
-          - name: Foreman Client 3.9 EL8 x86_64
-            content_type: yum
-            label: foreman39el8_client
-            url: https://yum.theforeman.org/client/3.9/el8/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       - name: Foreman Client 3.9 EL9
         label: foremanclient39el9
-        repositories:
-          - name: Foreman Client 3.9 EL9 x86_64
-            content_type: yum
-            label: foreman39el9_client
-            url: https://yum.theforeman.org/client/3.9/el9/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       # Foreman 3.10
       - name: Foreman Client 3.10 EL7
         label: foremanclient310el7


### PR DESCRIPTION
It's no longer used in any old content views, so it's time to fully remove the repo.