### PR TITLE
fix(hostgroup): Wrong hostgroup for vm-2001

### DIFF
--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -207,7 +207,7 @@
         compute_profile: "1-Small"
       - name: vm-2001.dmz.int.rabe.ch
         description: AlmaLinux 9 DMZ virtual machine vm-2001 for running reverse-proxy container
-        parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 DMZ server-009 VMs
+        parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 DMZ server-008 VMs
         organization: RaBe
         location: Randweg
         ansible_roles:


### PR DESCRIPTION
Fix a copypasta fail, where vm-2001 hostgroup mistakenly gets attached to server-009 hostgroup.