### PR TITLE
feat(host-group): set default network backend to slirp4netns

### DIFF
--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -314,6 +314,8 @@
             value:
               containers:
                 log_size_max: 1073741824 # 1Gib in bytes
+              network:
+                default_rootless_network_cmd: slirp4netns
           - name: radiorabe_git_local_clone
             parameter_type: boolean
             value: true
@@ -438,6 +440,8 @@
             value:
               containers:
                 log_size_max: 1073741824 # 1Gib in bytes
+              network:
+                default_rootless_network_cmd: slirp4netns
           - name: radiorabe_git_local_clone
             parameter_type: boolean
             value: true


### PR DESCRIPTION
This is required because the default network backend passt/pasta (0^20240806.gee36266) does not work very well for proxy and forwarded requests timeout. Needs to be re-evaluated when newer versions of passt are available.