### PR TITLE
fix(foreman): Render ansible_host on host, not on foreman

### DIFF
--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -274,7 +274,7 @@
                         image: ghcr.io/radiorabe/httpd:0.5.4
                         env:
                           - name: PODMAN_HOST
-                            value: "{{ ansible_host }}"
+                            value: "{{'{{ ansible_host }}'}}"
                         ports:
                           - containerPort: 8080
                             hostPort: 8080
@@ -400,7 +400,7 @@
                         image: ghcr.io/radiorabe/httpd:0.5.4
                         env:
                           - name: PODMAN_HOST
-                            value: "{{ ansible_host }}"
+                            value: "{{'{{ ansible_host }}'}}"
                         ports:
                           - containerPort: 8080
                             hostPort: 8080


### PR DESCRIPTION
Render `{{ ansible_host }}` as a string instead of interpolating it before it gets stored in foreman.

* fixes #205 