### PR TITLE
fix: separate certs for sso and default - step 1

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yaml
+++ b/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yaml
@@ -17,7 +17,8 @@ foreman_hostgroup:
       parameter_type: yaml
       value:
         - archiv.rabe.ch
-        - default.rabe.ch,sso.rabe.ch
+        - default.rabe.ch
+        - sso.rabe.ch
         - dmz-rev-proxy.ewb.rabe.ch
         - dmz-rev-proxy.upc.rabe.ch
         - intranet.rabe.ch

--- a/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yml
@@ -18,6 +18,7 @@ foreman_hostgroup:
       value:
         - archiv.rabe.ch
         - default.rabe.ch,sso.rabe.ch
+        - sso.rabe.ch
         - dmz-rev-proxy.ewb.rabe.ch
         - dmz-rev-proxy.upc.rabe.ch
         - intranet.rabe.ch


### PR DESCRIPTION
Adds a dedicated sso.rabe.ch cert so we don't rely on a SAN entry in default.rabe.ch anymore.

Removal of the domain from default.rabe.ch SANs will be done once new cert is available.
* part of #222 
* part of https://github.com/radiorabe/container-image-keycloak/issues/38