### PR TITLE
feat(host_groups): align code base with what's set in foreman

### DIFF
--- a/roles/foreman/tasks/host_groups.yaml
+++ b/roles/foreman/tasks/host_groups.yaml
@@ -28,8 +28,8 @@
             value:
               - name: monger-cockpit
                 dns:
-                - "{{ ansible_host }}"
-                principal: HTTP/{{ ansible_host }}@INT.RABE.CH
+                - "{{'{{ ansible_host }}'}}"
+                principal: "HTTP/{{'{{ ansible_host }}'}}@INT.RABE.CH"
                 ca: ipa
                 key_size: 4096
           - name: cockpit_packages


### PR DESCRIPTION
Algin ansible roles and parameters set in parent host groups. @hairmare please check thoroughly, see e.g. comment.