### PR TITLE
build: hacky host groups dumper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ansible/
+.venv/
+__pycache__

--- a/README.md
+++ b/README.md
@@ -21,6 +21,53 @@ GitOps our Foreman. This is where most of our Foreman configuration lives.
 
 ## Development
 
+### Hostgroups Dumper
+
+The repository includes a hostgroup dumper that reads hostgroup data from Foreman
+and writes YAML files into `roles/foreman/vars/hostgroups/`.
+
+1. Create and activate a Python virtual environment:
+
+   ```bash
+   python3 -m venv .venv
+   source .venv/bin/activate
+   pip install --upgrade pip
+   pip install ansible ansible-lint ruamel.yaml
+   ansible-galaxy collection install theforeman.foreman
+   ```
+
+2. In the Foreman UI, create a Personal Access Token for your user:
+
+   `User menu` -> `My Account` -> `Personal Access Tokens` -> `Create token`
+
+   Save the token in a secure location, you won't be able to recover it once you close the Foreman UI.
+
+3. Run the dumper with your Foreman username and API token:
+
+   ```bash
+   export FOREMAN_SERVER_URL="https://foreman.service.int.rabe.ch"
+   export FOREMAN_USERNAME="your-user"
+   export FOREMAN_API_TOKEN="your-personal-access-token"
+
+   source .venv/bin/activate
+   ansible-playbook \
+     -e foreman_server_url="$FOREMAN_SERVER_URL" \
+     -e foreman_username="$FOREMAN_USERNAME" \
+     -e foreman_password="$FOREMAN_API_TOKEN" \
+     -e foreman_validate_certs=false \
+     hack/playbooks/dump_foreman_hostgroups.yaml
+   ```
+
+4. Review changes
+
+   The resulting output might need some cleanup in edge cases.
+
+   Verify the output using git:
+
+   ```bash
+   git diff roles/foreman/vars/hostgroups/
+   ```
+
 ### Adding a Product and Repositories
 
 * add the product and repo in `roles/content/tasks/products.yaml`

--- a/hack/playbooks/dump_foreman_hostgroups.yaml
+++ b/hack/playbooks/dump_foreman_hostgroups.yaml
@@ -1,0 +1,136 @@
+---
+# Dump Host Groups from Foreman
+#
+# Helps manage the hostgroups in `roles/foreman/vars/hostgroups/*.yaml`.
+#
+# It updates existing files based on the data in the hostgroup and
+# creates new files when hostgroups are added.
+# It tries to preserve the file structure as much as possible, this
+# is mostly implemented by using ruamel.yaml for writing the file.
+#
+# It has some limitations:
+# - Multi-line strings and jinja2 templates are not always dumped properly
+# - It doesn't preserve file-first ordering for deeply nested YAML
+# - It seems to be too eager in dumping some inherited values:
+#   - operatingsystem
+#   - lifecycle_environment
+#   - content_view
+#   - architecture (workaround in place to ignore default)
+#   - compute_* (should be avoided due to EOL anyway)
+# - The code is a bit hacky
+#
+# Hence dumped files need to be reviewed carefully
+#
+# You can run this playbook like so:
+#
+#   ansible-playbook -e foreman_server_url=<SERVER> -e foreman_username=<USER> -e foreman_password=<TOKEN> hack/playbooks/dump_foreman_hostgroups.yaml
+#
+# Use git to analyse the resulting diff:
+#
+#   git diff roles/foreman/vars/hostgroups
+#
+# Consider cleaning up the dump with `ansible-lint`:
+#
+#   ansible-lint --fix=all roles/foreman/vars/hostgroups/
+#
+- name: Dump hostgroups from Foreman
+  hosts: localhost
+  connection: local
+  vars:
+    repo_root: "{{ playbook_dir | dirname | dirname }}"
+    hostgroups_vars_dir: "{{ playbook_dir }}/../../roles/foreman/vars/hostgroups"
+  tasks:
+    - name: "List hostgroup variable files"
+      ansible.builtin.set_fact:
+        hostgroup_var_files: "{{ query('fileglob', hostgroups_vars_dir ~ '/*.yaml') | sort }}"
+
+    - name: "Build existing hostgroup dump plan"
+      ansible.builtin.set_fact:
+        existing_hostgroups_to_dump: "{{ (existing_hostgroups_to_dump | default([])) + [{'name': _hostgroup_name, 'query_name': _hostgroup_query_name, 'dest': item}] }}"
+      vars:
+        _hostgroup_data: "{{ (lookup('ansible.builtin.file', item) | from_yaml).foreman_hostgroup }}"
+        _hostgroup_name: "{{ _hostgroup_data.name }}"
+        _hostgroup_parent: "{{ _hostgroup_data.parent | default('') }}"
+        _hostgroup_query_name: "{{ (_hostgroup_parent ~ '/' if _hostgroup_parent else '') ~ _hostgroup_name }}"
+      loop: "{{ hostgroup_var_files }}"
+
+    - name: "Build depth to filename prefix map"
+      ansible.builtin.set_fact:
+        depth_prefix_map: "{{ (depth_prefix_map | default({})) | combine({(_query_depth | string): _file_prefix}) }}"
+      vars:
+        _query_depth: "{{ (item.query_name.split('/')) | length }}"
+        _file_basename: "{{ item.dest | basename }}"
+        _file_prefix: "{{ _file_basename | regex_replace('^([0-9]{2})_.*$', '\\1') }}"
+      when:
+        - (item.dest | basename) is match('^[0-9]{2}_.+')
+        - (_query_depth | string) not in (depth_prefix_map | default({}))
+      loop: "{{ existing_hostgroups_to_dump | default([]) }}"
+
+    - name: "Read all hostgroups from Foreman"
+      theforeman.foreman.hostgroup_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+      register: all_hostgroups_info
+
+    - name: "Build complete hostgroup dump plan"
+      ansible.builtin.set_fact:
+        hostgroups_to_dump: "{{ (hostgroups_to_dump | default([])) + [{'name': item.name, 'query_name': item.title, 'dest': _dest_path}] }}"
+      vars:
+        _existing_matches: "{{ (existing_hostgroups_to_dump | default([])) | selectattr('query_name', 'equalto', item.title) | list }}"
+        _existing_dest: "{{ _existing_matches[0].dest if (_existing_matches | length > 0) else None }}"
+        _all_parent_titles: "{{ all_hostgroups_info.hostgroups | default([]) | map(attribute='parent_name') | select('defined') | reject('equalto', None) | list }}"
+        _depth_key: "{{ (item.title.split('/') | length | int) | string }}"
+        _depth_prefix: "{{ depth_prefix_map[_depth_key] if (_depth_key in (depth_prefix_map | default({}))) else ('%02d' | format(((item.title.split('/') | length | int) - 1))) }}"
+        _generated_name: "{{ (item.name | default('') | lower) | regex_replace('[^a-z0-9._-]+', '_') | regex_replace('^_+|_+$', '') | regex_replace('[.]yaml$', '') }}"
+        _is_fqdn_name: "{{ ((item.name | default('') | lower) is match('^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?:[.][a-z0-9](?:[a-z0-9-]*[a-z0-9])?)+$')) }}"
+        _is_leaf_hostgroup: "{{ _is_fqdn_name and (((_all_parent_titles | default([])) | select('equalto', (item.title | default(''))) | list | length) == 0) }}"
+        _dest_path: "{{ _existing_dest if _existing_dest else (hostgroups_vars_dir ~ '/' ~ (_generated_name ~ '.yaml' if _is_leaf_hostgroup else (_depth_prefix ~ '_' ~ _generated_name) ~ '.yaml' )) }}"
+      loop: "{{ all_hostgroups_info.hostgroups | default([]) | sort(attribute='title') }}"
+      loop_control:
+        label: "{{ item.title }}"
+
+    - name: "Read hostgroups"
+      theforeman.foreman.hostgroup_info:
+        username: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        server_url: "{{ foreman_server_url }}"
+        validate_certs: "{{ foreman_validate_certs }}"
+        name: "{{ item.query_name }}"
+      loop: "{{ hostgroups_to_dump }}"
+      register: hostgroup_infos
+
+    - name: "Read hostgroup ansible roles"
+      ansible.builtin.uri:
+        url: "{{ foreman_server_url }}/api/hostgroups/{{ item.hostgroup.id }}/ansible_roles"
+        method: GET
+        user: "{{ foreman_username }}"
+        password: "{{ foreman_password }}"
+        force_basic_auth: true
+        validate_certs: "{{ foreman_validate_certs }}"
+        headers:
+          Accept: "application/json;version=2"
+        return_content: true
+        status_code: 200
+      loop: "{{ hostgroup_infos.results }}"
+      register: hostgroup_ansible_roles
+      loop_control:
+        label: "{{ item.item.query_name }}"
+
+    - name: "Build hostgroup roles map"
+      ansible.builtin.set_fact:
+        hostgroup_roles_by_id: "{{ (hostgroup_roles_by_id | default({})) | combine({(item.item.hostgroup.id | string): (item.json | default([]))}) }}"
+      loop: "{{ hostgroup_ansible_roles.results }}"
+      loop_control:
+        label: "{{ item.item.item.query_name }}"
+
+    - name: "Dump YAML to hostgroup variable files"
+      dump_hostgroup_yaml:
+        repo_root: "{{ repo_root }}"
+        output_path: "{{ item.item.dest }}"
+        hostgroup: "{{ item.hostgroup }}"
+        role_entries: "{{ hostgroup_roles_by_id[item.hostgroup.id | string] | default([]) }}"
+      loop: "{{ hostgroup_infos.results }}"
+      loop_control:
+        label: "{{ item.item.dest | basename }}"

--- a/hack/playbooks/library/dump_hostgroup_yaml.py
+++ b/hack/playbooks/library/dump_hostgroup_yaml.py
@@ -1,0 +1,358 @@
+#!/usr/bin/python
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from io import StringIO
+
+from ansible.module_utils.basic import AnsibleModule
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.scalarstring import (
+    DoubleQuotedScalarString,
+    LiteralScalarString,
+)
+
+
+def _yaml_loader():
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.explicit_start = True
+    yaml.width = 4096
+    yaml.indent(mapping=2, sequence=4, offset=2)
+    return yaml
+
+
+def _to_plain(value):
+    if isinstance(value, dict):
+        return {k: _to_plain(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_to_plain(v) for v in value]
+    return value
+
+
+def _to_yaml_node(value):
+    if isinstance(value, dict):
+        out = CommentedMap()
+        for key, val in value.items():
+            out[key] = _to_yaml_node(val)
+        return out
+    if isinstance(value, list):
+        out = CommentedSeq()
+        for item in value:
+            out.append(_to_yaml_node(item))
+        return out
+    if isinstance(value, str):
+        if "\n" in value:
+            return LiteralScalarString(value)
+        if "{{" in value or "{%" in value:
+            return DoubleQuotedScalarString(value)
+    return value
+
+
+def _json_equal(a, b):
+    return json.dumps(_to_plain(a), sort_keys=True) == json.dumps(
+        _to_plain(b), sort_keys=True
+    )
+
+
+def _plain_equal(a, b):
+    return _json_equal(_to_plain(a), _to_plain(b))
+
+
+def _load_existing_content(repo_root, output_path):
+    if os.path.exists(output_path):
+        with open(output_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    rel_path = None
+    abs_repo = os.path.abspath(repo_root)
+    abs_output = os.path.abspath(output_path)
+    if abs_output.startswith(abs_repo + os.sep):
+        rel_path = os.path.relpath(abs_output, abs_repo)
+
+    if rel_path:
+        proc = subprocess.run(
+            [
+                "git",
+                "-C",
+                abs_repo,
+                "--no-pager",
+                "show",
+                f"HEAD:{rel_path}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return proc.stdout
+
+    return ""
+
+
+def _normalize_role_entries(role_entries):
+    if isinstance(role_entries, dict):
+        entries = role_entries.get("results")
+        return entries if isinstance(entries, list) else []
+    if isinstance(role_entries, list):
+        return role_entries
+    return []
+
+
+def _normalize_doc_start(content):
+    if not content.strip():
+        return "---\n"
+
+    if content.startswith("---"):
+        return re.sub(r"\A(?:---\s*\n)+", "---\n", content, count=1)
+
+    return "---\n" + content.lstrip()
+
+
+def _normalize_params(existing_params, source_params):
+    normalized = []
+    seen = []
+
+    source_by_name = {
+        p.get("name"): p for p in source_params if isinstance(p, dict) and p.get("name")
+    }
+
+    # Preserve ordering from existing file for params
+    # that still exist in Foreman.
+    for existing in existing_params:
+        if not isinstance(existing, dict):
+            continue
+        name = existing.get("name")
+        if not name or name not in source_by_name:
+            continue
+
+        source = source_by_name[name]
+        source_hidden = bool(
+            source.get("hidden_value?", source.get("hidden_value", False))
+        )
+        item = {
+            "name": name,
+            "parameter_type": source.get("parameter_type", "string"),
+            "value": source.get("value"),
+        }
+        if source_hidden:
+            item["hidden_value"] = True
+        normalized.append(item)
+        seen.append(name)
+
+    # Append newly discovered Foreman params after existing-ordered ones.
+    for source in source_params:
+        if not isinstance(source, dict):
+            continue
+        name = source.get("name")
+        if not name or name in seen:
+            continue
+
+        source_hidden = bool(
+            source.get("hidden_value?", source.get("hidden_value", False))
+        )
+        item = {
+            "name": name,
+            "parameter_type": source.get("parameter_type", "string"),
+            "value": source.get("value"),
+        }
+        if source_hidden:
+            item["hidden_value"] = True
+        normalized.append(item)
+
+    return normalized
+
+
+def _merge_parameter_seq(existing_seq, new_params):
+    if not isinstance(existing_seq, CommentedSeq):
+        return _to_yaml_node(new_params)
+
+    existing_by_name = {}
+    for item in existing_seq:
+        if isinstance(item, CommentedMap):
+            name = item.get("name")
+            if name:
+                existing_by_name[name] = item
+
+    merged_seq = CommentedSeq()
+    for param in new_params:
+        name = param.get("name") if isinstance(param, dict) else None
+        existing_item = existing_by_name.get(name)
+
+        if isinstance(existing_item, CommentedMap):
+            # Remove keys no longer present in Foreman data.
+            for key in list(existing_item.keys()):
+                if key not in param:
+                    del existing_item[key]
+
+            # Update values while retaining comments attached
+            # to existing nodes.
+            for key, value in param.items():
+                if key in existing_item and _plain_equal(existing_item[key], value):
+                    continue
+                existing_item[key] = _to_yaml_node(value)
+
+            # Keep predictable key order inside each parameter item.
+            for key in param.keys():
+                if key in existing_item:
+                    existing_item.move_to_end(key)
+
+            merged_seq.append(existing_item)
+        else:
+            merged_seq.append(_to_yaml_node(param))
+
+    return merged_seq
+
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec={
+            "repo_root": {"type": "path", "required": True},
+            "output_path": {"type": "path", "required": True},
+            "hostgroup": {"type": "dict", "required": True},
+            "role_entries": {
+                "type": "list",
+                "elements": "dict",
+                "required": False,
+                "default": [],
+            },
+        },
+        supports_check_mode=True,
+    )
+
+    repo_root = module.params["repo_root"]
+    output_path = module.params["output_path"]
+    hostgroup = module.params["hostgroup"] or {}
+    role_entries = _normalize_role_entries(module.params["role_entries"] or [])
+
+    existing_content = _load_existing_content(repo_root, output_path)
+    existing_trimmed = existing_content.strip()
+
+    yaml = _yaml_loader()
+    existing_data = yaml.load(existing_trimmed) if existing_trimmed else CommentedMap()
+    if existing_data is None:
+        existing_data = CommentedMap()
+
+    existing_hostgroup_rt = existing_data.get("foreman_hostgroup", CommentedMap())
+    existing_hostgroup = _to_plain(
+        existing_hostgroup_rt if isinstance(existing_hostgroup_rt, dict) else {}
+    )
+
+    source_params = hostgroup.get("parameters") or []
+    existing_params = existing_hostgroup.get("parameters") or []
+    merged_params = _normalize_params(existing_params, source_params)
+
+    fetched_roles = [
+        r.get("name")
+        for r in role_entries
+        if isinstance(r, dict) and not r.get("inherited", False) and r.get("name")
+    ]
+    roles_value = fetched_roles if fetched_roles else None
+
+    merged_architecture = hostgroup.get("architecture_name")
+    dumped_architecture = (
+        None if merged_architecture == "x86_64" else merged_architecture
+    )
+
+    orgs = hostgroup.get("organizations") or []
+    locs = hostgroup.get("locations") or []
+
+    updates = {
+        "name": hostgroup.get("name"),
+        "description": hostgroup.get("description"),
+        "parent": hostgroup.get("parent_name"),
+        "organization": (
+            orgs[0].get("name") if len(orgs) > 0 and isinstance(orgs[0], dict) else None
+        ),
+        "locations": (
+            [
+                loc.get("name")
+                for loc in locs
+                if isinstance(loc, dict) and loc.get("name")
+            ]
+            if len(locs) > 0
+            else None
+        ),
+        "domain": hostgroup.get("domain_name"),
+        "subnet": hostgroup.get("subnet_name"),
+        "architecture": dumped_architecture,
+        "operatingsystem": hostgroup.get("operatingsystem_name"),
+        "lifecycle_environment": hostgroup.get("lifecycle_environment_name"),
+        "content_view": hostgroup.get("content_view_name"),
+        "compute_resource": hostgroup.get("compute_resource_name"),
+        "compute_profile": hostgroup.get("compute_profile_name"),
+        "ansible_roles": roles_value,
+        "parameters": merged_params if merged_params else None,
+    }
+
+    merged_hostgroup = updates
+
+    ordered_keys = list(existing_hostgroup.keys())
+    for key in updates.keys():
+        if key not in ordered_keys:
+            ordered_keys.append(key)
+
+    merged_ordered = CommentedMap()
+    for key in ordered_keys:
+        if key in merged_hostgroup and merged_hostgroup.get(key) is not None:
+            merged_ordered[key] = merged_hostgroup.get(key)
+
+    if existing_hostgroup and _json_equal(
+        _to_plain(merged_ordered), existing_hostgroup
+    ):
+        rendered = _normalize_doc_start(existing_content)
+    else:
+        out_data = existing_data if isinstance(existing_data, dict) else CommentedMap()
+        fg = out_data.get("foreman_hostgroup")
+        if not isinstance(fg, CommentedMap):
+            fg = CommentedMap()
+
+        for key in list(fg.keys()):
+            if key not in merged_ordered:
+                del fg[key]
+
+        for key, value in merged_ordered.items():
+            if key == "parameters" and isinstance(value, list):
+                fg[key] = _merge_parameter_seq(fg.get(key), value)
+                continue
+            if key in fg and _plain_equal(fg[key], value):
+                continue
+            fg[key] = _to_yaml_node(value)
+
+        for key in merged_ordered.keys():
+            if key in fg:
+                fg.move_to_end(key)
+
+        out_data["foreman_hostgroup"] = fg
+
+        buf = StringIO()
+        yaml.dump(out_data, buf)
+        rendered = buf.getvalue()
+
+    changed = rendered != existing_content
+
+    if changed and not module.check_mode:
+        os.makedirs(os.path.dirname(output_path), exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(rendered)
+
+    result = {
+        "changed": changed,
+        "output_path": output_path,
+    }
+    if getattr(module, "_diff", False):
+        result["diff"] = {"before": existing_content, "after": rendered}
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This diff from the dump here won't be endless, so it only get's us started towards having some (manual) validation scripting.

The dumper is mostly correct now that is uses ruamel, there are some edge cases like dumping scalars with jinja templates that need to resolved on the final host and not the ansible runtime. Those are pretty rare and the dumper still provides value without supporting them.