### PR TITLE
chore(content): stop syncing EL8

### DIFF
--- a/roles/content/tasks/sync_plans.yaml
+++ b/roles/content/tasks/sync_plans.yaml
@@ -9,14 +9,11 @@
         sync_date: 2020-11-07 00:00:00 UTC
         products:
           - CentOS 7
-          - AlmaLinux 8
           - AlmaLinux 9
           - RaBe Ansible
           - Extra Packages for Enterprise Linux 7
-          - Extra Packages for Enterprise Linux 8
           - Extra Packages for Enterprise Linux 9
           - Foreman Client 3.12 EL7
-          - Foreman Client 3.12 EL8
           - Foreman Client 3.12 EL9
           - RaBe Logstash Addons EL7
           - Zabbix 3.0 (LTS) EL7
@@ -24,7 +21,6 @@
           - Zabbix 6.4 EL9
           - Zabbix 7.0 EL9
           - RaBe Linux EL7
-          - RaBe Linux EL8
           - RaBe Linux EL9
           - Paravel Systems EL7
           - LibreTime EL7


### PR DESCRIPTION
We are starting to introduce EL10 and there are no EL8 users, let's clean house and start getting rid of EL8 by stopping to sync it.