### PR TITLE
feat(vm-0044): add keycloak-01 deployment

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0044.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0044.service.int.rabe.ch.yml
@@ -1,0 +1,220 @@
+---
+foreman_hostgroup:
+  name: vm-0044.service.int.rabe.ch
+  description: Keycloak Host (keycloak-01)
+  parent: RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 VMs
+  organization: RaBe
+  locations:
+    - Sulgenrain
+  operatingsystem: AlmaLinux 9
+  lifecycle_environment: Prod
+  content_view: AlmaLinux 9 x86_64
+  ansible_roles:
+    - theforeman.foreman_scap_client
+    - redhat.rhel_system_roles.kernel_settings
+    - redhat.rhel_system_roles.certificate
+    - radiorabe.common.local_user
+    - redhat.rhel_system_roles.podman
+    - radiorabe.rabe_zabbix.agent
+    - radiorabe.podman.zabbix_monitoring
+  parameters:
+    - name: certificate_requests
+      parameter_type: yaml
+      value:
+        - name: keycloak-01
+          dns:
+            - keycloak-01.service.int.rabe.ch
+          key_size: 4096
+          ca: ipa
+          principal: HTTP/keycloak-01.service.int.rabe.ch@INT.RABE.CH
+          run_after: |
+            mkdir /home/keycloak/ssl
+            cd /home/keycloak
+            /usr/bin/cp /etc/pki/tls/*/keycloak-01.* /home/keycloak/ssl/
+            /usr/bin/chown keycloak: /home/keycloak/ssl/*
+            /usr/bin/sudo -u keycloak /usr/bin/podman pod restart keycloak
+    - name: firewall
+      parameter_type: yaml
+      value:
+        - zone: service
+          state: present
+          permanent: true
+        - zone: service
+          interface: enp1s0
+          state: enabled
+          permanent: true
+        - zone: service
+          service:
+            - ssh
+            - cockpit
+          state: enabled
+          permanent: true
+        - set_default_zone: service
+          permanent: true
+    - name: kernel_settings_sysctl
+      parameter_type: yaml
+      value:
+        - name: net.ipv4.ip_unprivileged_port_start
+          value: 80
+    - name: keycloak_bootstrap_admin_password
+      parameter_type: string
+      value: "{{ '{{' }} undef('variable keycloak_bootstrap_admin_password needs to be set in host') {{ '}}' }}"
+    - name: keycloak_database_password
+      parameter_type: string
+      value: "{{ '{{' }} undef('variable keycloak_database_password needs to be set in host') {{ '}}' }}"
+    - name: local_user_groupname
+      parameter_type: string
+      value: keycloak
+    - name: local_user_username
+      parameter_type: string
+      value: keycloak
+    - name: podman_containers_conf
+      parameter_type: yaml
+      value:
+        containers:
+          log_driver: k8s-file
+          log_size_max: 1073741824
+    - name: podman_create_host_directories
+      parameter_type: boolean
+      value: true
+    - name: podman_firewall
+      parameter_type: yaml
+      value:
+        - zone: service
+          service:
+            - http
+            - https
+          state: enabled
+          permanent: true
+    - name: podman_kube_specs
+      parameter_type: yaml
+      value:
+        - state: started
+          kube_file_content:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: postgresql
+            spec:
+              containers:
+                - name: postgresql
+                  restart: always
+                  image: ghcr.io/radiorabe/postgresql:0.2.2@sha256:72d7eebd4a3f0eb1b5323b75811972057e8365de6d2b7f1e9c310efc0c0757a1
+                  ports:
+                    - containerPort: 5432
+                      hostPort: 5432
+                  volumeMounts:
+                    - mountPath: /var/lib/pgsql/data:Z,U
+                      name: pgdata
+                    - mountPath: /var/run/postgresql:Z,U
+                      name: run
+                  env:
+                    - name: POSTGRESQL_USER
+                      value: keycloak
+                    - name: POSTGRESQL_DATABASE
+                      value: keycloak
+                    - name: POSTGRESQL_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: postgresql
+                          key: database_password
+              volumes:
+                - name: pgdata
+                  hostPath:
+                    path: /home/keycloak/pgdata
+                - name: run
+                  emptyDir: {}
+        - state: started
+          kube_file_content:
+            apiVersion: v1
+            kind: Pod
+            metadata:
+              name: keycloak
+            spec:
+              containers:
+                - name: keycloak
+                  restart: always
+                  image: ghcr.io/radiorabe/keycloak:0.8.7@sha256:6e8ee7ae9655764ae16ebd6d520eb5b722632371289124678f1b138922055e91
+                  command:
+                    - /opt/keycloak/bin/kc.sh
+                    - start
+                    - --optimized
+                  ports:
+                    - containerPort: 8080
+                      hostPort: 80
+                    - containerPort: 8443
+                      hostPort: 443
+                  volumeMounts:
+                    - mountPath: /opt/keycloak/conf/truststores/ssl:Z,U
+                      name: ssl
+                    - mountPath: /opt/keycloak/data/tmp:Z,U
+                      name: tmp
+                  env:
+                    - name: KC_BOOTSTRAP_ADMIN_USERNAME
+                      value: temp-admin
+                    - name: KC_BOOTSTRAP_ADMIN_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: keycloak
+                          key: bootstrap_admin_password
+                    - name: KC_HOSTNAME
+                      value: keycloak-01.service.int.rabe.ch
+                    - name: KC_HTTPS_CERTIFICATE_FILE
+                      value: /opt/keycloak/conf/truststores/ssl/keycloak-01.crt
+                    - name: KC_HTTPS_CERTIFICATE_KEY_FILE
+                      value: /opt/keycloak/conf/truststores/ssl/keycloak-01.key
+                    - name: KC_HOSTNAME_STRICT
+                      value: 'false'
+                    - name: KC_DB_URL
+                      value: jdbc:postgresql://postgresql/keycloak
+                    - name: KC_DB_USERNAME
+                      value: keycloak
+                    - name: KC_DB_PASSWORD
+                      valueFrom:
+                        secretKeyRef:
+                          name: keycloak
+                          key: database_password
+              volumes:
+                - name: ssl
+                  hostPath:
+                    path: /home/keycloak/ssl
+                - name: tmp
+                  emptyDir: {}
+    - name: podman_run_as_group
+      parameter_type: string
+      value: keycloak
+    - name: podman_run_as_user
+      parameter_type: string
+      value: keycloak
+    - name: podman_secrets
+      parameter_type: yaml
+      value:
+        - state: present
+          name: postgresql
+          data:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: postgresql
+            data:
+              database_password: "{{ '{{' }} keycloak_database_password | ansible.builtin.b64encode {{ '}}' }}"
+        - state: present
+          name: keycloak
+          data:
+            apiVersion: v1
+            kind: Secret
+            metadata:
+              name: keycloak
+            data:
+              bootstrap_admin_password: "{{ '{{' }} keycloak_bootstrap_admin_password | ansible.builtin.b64encode {{ '}}' }}"
+              database_password: "{{ '{{' }} keycloak_database_password | ansible.builtin.b64encode {{ '}}' }}"
+    - name: podman_selinux_ports
+      parameter_type: yaml
+      value:
+        - ports: 80
+          setype: http_port_t
+        - ports: 443
+          setype: http_port_t
+    - name: zabbix_monitoring_podman_user
+      parameter_type: string
+      value: "{{ '{{' }} podman_run_as_user {{ '}}' }}"


### PR DESCRIPTION
Adds a new Foreman hostgroup for `vm-0044.service.int.rabe.ch` to support the containerized Keycloak deployment (`keycloak-01`).

## What changed
- Added `roles/foreman/vars/hostgroups/vm-0044.service.int.rabe.ch.yaml`
- Created a new Foreman hostgroup with:
  - Hostgroup name: `vm-0044.service.int.rabe.ch`
  - Description: `Keycloak Host (keycloak-01)`
  - Parent group under `RaBe Core/RaBe Base/EL9/AlmaLinux 9/AlmaLinux 9 VMs`
  - Organization: `RaBe`
  - Location: `Sulgenrain`
  - OS: `AlmaLinux 9`
  - Lifecycle environment: `Prod`
  - Content view: `AlmaLinux 9 x86_64`

## Configuration details
- Assigned Ansible roles for SCAP client, kernel settings, certificates, Podman, local user management, and Zabbix agent installation.
- Configured certificate requests for `keycloak-01.service.int.rabe.ch` with an IPA CA principal and a post-request hook to copy TLS artifacts and restart the Keycloak Podman pod.
- Configured firewall rules for the `service` zone, including SSH and Cockpit access and default service zone enforcement.
- Set `net.ipv4.ip_unprivileged_port_start` to `80` via kernel sysctl settings.
- Added required hostgroup parameters for Keycloak bootstrap and database passwords.
- Configured Podman runtime defaults, host directories, firewall rules, and container specs.
- Added two Podman-managed containers:
  - PostgreSQL container using `ghcr.io/radiorabe/postgresql`
  - Keycloak container using `ghcr.io/radiorabe/keycloak`
- Added Podman secrets for PostgreSQL and Keycloak credentials, with values encoded from secret variables.
- Added SELinux port labels for HTTP and HTTPS.
- Added Podman monitoring config with Zabbix agent2