### PR TITLE
feat(content): remove Foreman Client 3.10 from Foreman and 3.9 from GitOps

### DIFF
--- a/roles/content/tasks/products.yaml
+++ b/roles/content/tasks/products.yaml
@@ -308,44 +308,16 @@
             download_policy: on_demand
             auto_enabled: false
       # All of our distros should have access to foreman client tooling.
-      # Foreman 3.9
-      - name: Foreman Client 3.9 EL7
-        label: foremanclient39el7
-        state: absent
-      - name: Foreman Client 3.9 EL8
-        label: foremanclient39el8
-        state: absent
-      - name: Foreman Client 3.9 EL9
-        label: foremanclient39el9
-        state: absent
       # Foreman 3.10
       - name: Foreman Client 3.10 EL7
         label: foremanclient310el7
-        repositories:
-          - name: Foreman Client 3.10 EL7 x86_64
-            content_type: yum
-            label: foreman310el7_client
-            url: https://yum.theforeman.org/client/3.10/el7/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       - name: Foreman Client 3.10 EL8
         label: foremanclient310el8
-        repositories:
-          - name: Foreman Client 3.10 EL8 x86_64
-            content_type: yum
-            label: foreman310el8_client
-            url: https://yum.theforeman.org/client/3.10/el8/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       - name: Foreman Client 3.10 EL9
         label: foremanclient310el9
-        repositories:
-          - name: Foreman Client 3.10 EL9 x86_64
-            content_type: yum
-            label: foreman310el9_client
-            url: https://yum.theforeman.org/client/3.10/el9/x86_64/
-            download_policy: on_demand
-            auto_enabled: true
+        state: absent
       # Foreman 3.11
       - name: Foreman Client 3.11 EL7
         label: foremanclient311el7


### PR DESCRIPTION
Lfecycle maintenance as per README 🥳 