### PR TITLE
chore(hostgroups): thin epn config file on vm-0045 and add ansible managed annotation + html indentfix

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0045.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0045.service.int.rabe.ch.yml
@@ -29,155 +29,109 @@ foreman_hostgroup:
         - dest: /etc/ipa/epn.conf
           mode: '0600'
           content: |
-            # This file is a copy from https://github.com/freeipa/freeipa/blob/master/client/share/epn.conf
-            #
-            # Global IPA-EPN [0] configuration file.
-            # For a complete explanation of each parameter, see the epn.conf(5)
-            # manual page.
-            # For best results, change no more than a single parameter at a time,
-            # and test if ipa-epn(1) still works as intended, using --dry-run when
-            # it makes sense.
-            #
-            # [0] https://github.com/freeipa/freeipa/blob/master/doc/designs/expiring-password-notification.md
+            # {{ ansible_managed }}
+            # See https://github.com/freeipa/freeipa/blob/master/client/share/epn.conf
             [global]
-            # Specifies the SMTP server to use.
             smtp_server = {{ smtp_server }}
-            # Specifies the SMTP port.
             smtp_port = {{ smtp_port | default('25') }}
-            # Specifies the id of the user to authenticate with the SMTP server.
-            # Default None (empty value).
             smtp_user = {{ smtp_user }}
-            # Specifies the password for the authorized user.
-            # Default None (empty value).
             smtp_password = {{ smtp_password }}
-            # Specifies the path to a single file in PEM format containing the certificate.
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
-            # Default None (empty value).
-            # smtp_client_cert =
-            # Specifies the path to a file containing the private key in. Otherwise the
-            # private key will be taken from certfile as well.
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
-            # Default None (empty value).
-            # smtp_client_key =
-            # Specifies the password for decrypting the private key. It will be ignored if
-            # the private key is not encrypted and no password is needed.
-            # https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_cert_chain
-            # Default None (empty value).
-            # smtp_client_key_pass =
-            # Specifies the number of seconds to wait for SMTP to respond.
             smtp_timeout = 60
-            # Specifies the type of secure connection to make. Options are: none,
-            # starttls and ssl.
             smtp_security = {{ smtp_security | default('none') }}
-            # Specifies the From e-mail address value in the e-mails sent. Bounces will
-            # be sent here.
             smtp_admin = {{ smtp_admin | default('root@localhost') }}
-            # Time to wait, in milliseconds, between each e-mail sent to try to avoid
-            # overloading the mail queue.
             smtp_delay = 0
-            # Specifies the From: e-mail address value in the e-mails sent.
-            # The default when unset is noreply@ipadefaultemaildomain.
-            # This value can be found by running ipa config-show.
             mail_from = {{ mail_from | default('noreply@ipadefaultemaildomain') }}
-            # Specifies the From: name value in the e-mails-sent.
-            # The default when unset is IPA-EPN.
-            # mail_from_name = {{ mail_from_name | default('IPA-EPN') }}
-            # The list of days before a password expiration when ipa-epn should notify
-            # a user that their password will soon require a reset.
             notify_ttls = {{ notify_ttls | default('28, 14, 7, 3, 1') }}
-            # Set the subject of the message
             msg_subject = {{ msg_subject }}
-            # Set the character set of the message.
             msg_charset = utf8
-            # Set the message's MIME sub-content type.
             msg_subtype = {{ msg_subtype | default('plain') }}
         - dest: /etc/ipa/epn/expire_msg.template
           mode: '0644'
           content: |-
             <!DOCTYPE html>
             <html>
-            <head>
-                <meta charset="utf-8" />
-                <meta http-equiv="X-UA-Compatible" content="IE=edge">
-                <meta content="width=device-width, initial-scale=1.0" name="viewport" />
-            </head>
-            <body >
-                <table style="background-color: #eee; font-family: 'Helvetica', 'Arial', sans-serif; padding: 20px; width: 100%; font-size: 14px;">
-                    <tr>
-                        <td>
-                            <center style="width: 100%; margin: auto; max-width: 560px;">
-                                <table class="row" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
-                                    <tr>
-                                        <td style="font-family: 'Helvetica', 'Arial', sans-serif;">
-                                            <table class="row" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
-                                                <tr>
-                                                    <td style="padding-bottom:12px; vertical-align: middle; width: 1%;">
-                                                        <img style="max-width: 100px; padding-left: 1px;" src="https://mein.fairgate.ch/uploads/1127/admin/clublogo_100/logo.jpg" />
-                                                    </td>
-                                                    <td style="width: 28px;"></td>
-                                                    <td style="font-family: 'Helvetica', 'Arial', sans-serif; vertical-align: middle;">
-                                                        <h1 style="margin: 0; font-size: 30px; font-weight: 500; margin-top: -4px;">RaBe Login</h1>
-                                                    </td>
-                                                </tr>
-                                            </table>
-                                        </td>
-                                    </tr>
-                                </table>
-                                <table style="background-color:#fff; border:1px solid #e1e1e1; width:100%;" cellpadding="0" cellspacing="0">
-                                    <tr>
-                                        <td style="padding-bottom: 20px; padding-left: 20px; padding-top: 20px; padding-right: 20px; font-family: 'Helvetica', 'Arial', sans-serif;">
-                                            <div style="overflow: hidden;">
-                                                <p>
-                                                    Liebe*r {{ '{{' }} first {{ '}}' }},
-                                                </p>
-                                                <p>
-                                                    Dein Passwort wird am  {{ '{{' }} expiration | datetimeformat('long', 'Europe/Berlin', 'de_DE') {{ '}}' }} ablaufen.
-                                                </p>
-                                                <p>
-                                                    Du kannst es ganz einfach mit unserem Self-Service unter <a href="https://my.rabe.ch" style="text-decoration: none; color:#2da6cb;">my.rabe.ch</a> erneuern.
-                                                    Siehe auch <a href="https://wiki.rabe.ch/Erste_Schritte" style="text-decoration: none; color:#2da6cb;">wiki.rabe.ch/Erste_Schritte</a> in unserem Wiki.
-                                                </p>
-                                                <p>Liebe Grüsse</p>
-                                                <p><a href="mailto:it@rabe.ch" style="text-decoration: none; color:#2da6cb;">RaBe IT-Reaktion</a></p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td>
-                                            <hr style="border: 0; border-top: 1px solid #e1e1e1; margin: 0;" />
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td style="padding-bottom: 20px; padding-left: 20px; padding-top: 20px; padding-right: 20px; font-family: 'Helvetica', 'Arial', sans-serif;">
-                                            <div style="overflow: hidden;">
-                                                <p>
-                                                    Dear {{ '{{' }} first {{ '}}' }},
-                                                </p>
-                                                <p>
-                                                    Your password will expire soon on {{ '{{' }} expiration | datetimeformat('long', 'Europe/Berlin') {{ '}}' }}.</p>
-                                                </p>
-                                                <p>
-                                                    You can easily renew it using our self-service at <a href="https://my.rabe.ch" style="text-decoration: none; color:#2da6cb;">my.rabe.ch</a>.
-                                                    See also <a href="https://wiki.rabe.ch/Erste_Schritte" style="text-decoration: none; color:#2da6cb;">wiki.rabe.ch/Erste_Schritte</a> in our wiki.
-                                                </p>
-                                                <p>Best wishes</p>
-                                                <p><a href="mailto:it@rabe.ch" style="text-decoration: none; color:#2da6cb;">RaBe IT-Reaktion</a></p>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                </table>
-                                <table cellpadding="0" cellspacing="0" border="0" style="width:100%">
-                                    <tr>
-                                        <td style="float:right; padding-top:10px; font-size:12px; display:inline-block; padding-left: 1px; text-align: right; font-family: 'Helvetica', 'Arial', sans-serif;">
-                                            <p>Mailing powered by <a href="https://www.rabe.ch" style="text-decoration: none;">RaBe</a></p>
-                                        </td>
-                                    </tr>
-                                </table>
-                            </center>
-                        </td>
-                    </tr>
-                </table>
-            </body>
+                <head>
+                    <meta charset="utf-8" />
+                    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+                </head>
+                <body >
+                    <table style="background-color: #eee; font-family: 'Helvetica', 'Arial', sans-serif; padding: 20px; width: 100%; font-size: 14px;">
+                        <tr>
+                            <td>
+                                <center style="width: 100%; margin: auto; max-width: 560px;">
+                                    <table class="row" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+                                        <tr>
+                                            <td style="font-family: 'Helvetica', 'Arial', sans-serif;">
+                                                <table class="row" cellpadding="0" cellspacing="0" border="0" style="width:100%;">
+                                                    <tr>
+                                                        <td style="padding-bottom:12px; vertical-align: middle; width: 1%;">
+                                                            <img style="max-width: 100px; padding-left: 1px;" src="https://mein.fairgate.ch/uploads/1127/admin/clublogo_100/logo.jpg" />
+                                                        </td>
+                                                        <td style="width: 28px;"></td>
+                                                        <td style="font-family: 'Helvetica', 'Arial', sans-serif; vertical-align: middle;">
+                                                            <h1 style="margin: 0; font-size: 30px; font-weight: 500; margin-top: -4px;">RaBe Login</h1>
+                                                        </td>
+                                                    </tr>
+                                                </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <table style="background-color:#fff; border:1px solid #e1e1e1; width:100%;" cellpadding="0" cellspacing="0">
+                                        <tr>
+                                            <td style="padding-bottom: 20px; padding-left: 20px; padding-top: 20px; padding-right: 20px; font-family: 'Helvetica', 'Arial', sans-serif;">
+                                                <div style="overflow: hidden;">
+                                                    <p>
+                                                        Liebe*r {{ '{{' }} first {{ '}}' }},
+                                                    </p>
+                                                    <p>
+                                                        Dein Passwort wird am  {{ '{{' }} expiration | datetimeformat('long', 'Europe/Berlin', 'de_DE') {{ '}}' }} ablaufen.
+                                                    </p>
+                                                    <p>
+                                                        Du kannst es ganz einfach mit unserem Self-Service unter <a href="https://my.rabe.ch" style="text-decoration: none; color:#2da6cb;">my.rabe.ch</a> erneuern.
+                                                        Siehe auch <a href="https://wiki.rabe.ch/Erste_Schritte" style="text-decoration: none; color:#2da6cb;">wiki.rabe.ch/Erste_Schritte</a> in unserem Wiki.
+                                                    </p>
+                                                    <p>Liebe Grüsse</p>
+                                                    <p><a href="mailto:it@rabe.ch" style="text-decoration: none; color:#2da6cb;">RaBe IT-Reaktion</a></p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td>
+                                                <hr style="border: 0; border-top: 1px solid #e1e1e1; margin: 0;" />
+                                            </td>
+                                        </tr>
+                                        <tr>
+                                            <td style="padding-bottom: 20px; padding-left: 20px; padding-top: 20px; padding-right: 20px; font-family: 'Helvetica', 'Arial', sans-serif;">
+                                                <div style="overflow: hidden;">
+                                                    <p>
+                                                        Dear {{ '{{' }} first {{ '}}' }},
+                                                    </p>
+                                                    <p>
+                                                        Your password will expire soon on {{ '{{' }} expiration | datetimeformat('long', 'Europe/Berlin') {{ '}}' }}.</p>
+                                                    </p>
+                                                    <p>
+                                                        You can easily renew it using our self-service at <a href="https://my.rabe.ch" style="text-decoration: none; color:#2da6cb;">my.rabe.ch</a>.
+                                                        See also <a href="https://wiki.rabe.ch/Erste_Schritte" style="text-decoration: none; color:#2da6cb;">wiki.rabe.ch/Erste_Schritte</a> in our wiki.
+                                                    </p>
+                                                    <p>Best wishes</p>
+                                                    <p><a href="mailto:it@rabe.ch" style="text-decoration: none; color:#2da6cb;">RaBe IT-Reaktion</a></p>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    <table cellpadding="0" cellspacing="0" border="0" style="width:100%">
+                                        <tr>
+                                            <td style="float:right; padding-top:10px; font-size:12px; display:inline-block; padding-left: 1px; text-align: right; font-family: 'Helvetica', 'Arial', sans-serif;">
+                                                <p>Mailing powered by <a href="https://www.rabe.ch" style="text-decoration: none;">RaBe</a></p>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </center>
+                            </td>
+                        </tr>
+                    </table>
+                </body>
             </html>
     - name: smtp_server
       parameter_type: string


### PR DESCRIPTION
This should solve the UI issues surfaced here: https://github.com/radiorabe/ansible-collection-rabe_foreman/pull/308#discussion_r3204266448

* add a `{{ ansible_managed }}` comment (we can config manage the var later, it's a proper ansible thing with a sensible default)
* remove all comments because one of them had a trailing EOL whitespace that is breaking the UI
* in the email, indent head and body properly because 🤷 

not sure if we can use `omit` in the config file context, do we want to waste some tokens on removing even more from epn.conf so it only overrides what we need?