### PR TITLE
fix(hostgroups): uncomment mail_from_name in vm-0045 epn.conf template

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0045.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0045.service.int.rabe.ch.yml
@@ -98,7 +98,7 @@ foreman_hostgroup:
 
             # Specifies the From: name value in the e-mails-sent.
             # The default when unset is IPA-EPN.
-            # mail_from_name = {{ mail_from_name | default('IPA-EPN') }}
+            mail_from_name = {{ mail_from_name | default('IPA-EPN') }}
 
             # The list of days before a password expiration when ipa-epn should notify
             # a user that their password will soon require a reset.


### PR DESCRIPTION
It looks like we'd want to uncomment the mail_from_name in the epc config template.

The other changes to the hostgroup look like legit prep work, this one looks like an unexpected omission from the config.