### PR TITLE
fix: separate certs for sso and default - step 2

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0043.service.int.rabe.ch.yml
@@ -17,7 +17,7 @@ foreman_hostgroup:
       parameter_type: yaml
       value:
         - archiv.rabe.ch
-        - default.rabe.ch,sso.rabe.ch
+        - default.rabe.ch
         - sso.rabe.ch
         - dmz-rev-proxy.ewb.rabe.ch
         - dmz-rev-proxy.upc.rabe.ch


### PR DESCRIPTION
Now that Keycloak no longer relies on the default certificate's SAN, we can remove the sso SAN from the default cert.

This concludes the cert cleanup and gets ron of the last remnant of our original "one cert with many SANs" config.