### PR TITLE
feat(content): Start removal of Zabbix 6.4 for EL9

### DIFF
--- a/roles/content/tasks/content_views.yml
+++ b/roles/content/tasks/content_views.yml
@@ -85,10 +85,6 @@
             product: Extra Packages for Enterprise Linux 9
           - name: Zabbix 7.0 Official Repository - EL9 - x86_64
             product: Zabbix 7.0 EL9
-          # TODO: move unsupported repo to 7.0 product and update here once done
-          # this is most likely a multi-step change
-          - name: Zabbix Official Repository (non-supported) - EL9 - x86_64
-            product: Zabbix 6.4 EL9
           - name: Trivy for EL9 (x84_64)
             product: Trivy
       - name: AlmaLinux 10 x86_64

--- a/roles/content/tasks/sync_plans.yml
+++ b/roles/content/tasks/sync_plans.yml
@@ -21,7 +21,6 @@
           - RaBe Logstash Addons EL7
           - Zabbix 3.0 (LTS) EL7
           - Zabbix 6.4 EL7
-          - Zabbix 6.4 EL9
           - Zabbix 7.0 EL9
           - Zabbix 7.0 EL10
           - RaBe Linux EL7


### PR DESCRIPTION
We keep it sticking around for EL7 because 6.4 is modern enough to taalk to 7.0, but we don't need it on EL9 anymore.