### PR TITLE
fix(content): Remove zabbix60el7 reference from activaton key

### DIFF
--- a/roles/content/tasks/activation_keys.yml
+++ b/roles/content/tasks/activation_keys.yml
@@ -65,9 +65,6 @@
             override: disabled
           - label: RaBe_epel7_epel7
             override: disabled
-          # disable modern zabbix until we update our server
-          - label: RaBe_zabbix60el7_zabbix60el7
-            override: disabled
           # disable postgresql repos per default as they are only for servers
           - label: RaBe_pgdg16el7_pgdg16el7_common
             override: disabled


### PR DESCRIPTION
Zabbix 6.0 has been gone for a while.