### PR TITLE
fix(content): Remove 404 and other legacy repos from sync

### DIFF
--- a/roles/content/tasks/sync_plans.yml
+++ b/roles/content/tasks/sync_plans.yml
@@ -18,7 +18,6 @@
           - Foreman Client 3.13 EL7
           - Foreman Client 3.14 EL9
           - Foreman Client 3.14 EL10
-          - RaBe Logstash Addons EL7
           - Zabbix 3.0 (LTS) EL7
           - Zabbix 6.4 EL7
           - Zabbix 7.0 EL9
@@ -26,9 +25,5 @@
           - RaBe Linux EL7
           - RaBe Linux EL9
           - Paravel Systems EL7
-          - LibreTime EL7
-          - RaBe Liquidsoap Distribution for EL7
           - Nux Dextop EL7
-          - RaBe Audio EL7
-          - PostgreSQL 15 EL7
           - Trivy


### PR DESCRIPTION
So we don't waste time and resources syncing unused resources.