### PR TITLE
fix(vm-0041): Remove unnecessary rabe_backup configuration

### DIFF
--- a/roles/foreman/vars/hostgroups/vm-0041.service.int.rabe.ch.yml
+++ b/roles/foreman/vars/hostgroups/vm-0041.service.int.rabe.ch.yml
@@ -208,10 +208,6 @@ foreman_hostgroup:
           setype: http_port_t
         - ports: 443
           setype: http_port_t
-    - name: rabe_backup_include_paths
-      parameter_type: yaml
-      value:
-        - /home/kanboard
     - name: radiorabe_copies
       parameter_type: yaml
       value:


### PR DESCRIPTION
I somehow missed that /home is part of the default locations to be backed up. Therefore this config is not required.